### PR TITLE
Create bug_report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: How did the bug happen? What should have happened?
+      description: Give clear replication steps
+      placeholder: Tell us what happened!
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Please attach relevant screenshots
+      placeholder: Show us what you see!
+    validations:
+      required: false
+  - type: dropdown
+    id: deviceOS
+    attributes:
+      label: What device are you seeing the problem on?
+      multiple: true
+      options:
+        - Web
+        - Apple
+        - Samsung
+


### PR DESCRIPTION
Added yaml file to provide a template for bug reports, prompts user to explain how to replicate the bug, what was expected to happen, on what OS, and to provide screenshots if possible.