### PR TITLE
Bug fix: define zoom level for building icons

### DIFF
--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -113,6 +113,7 @@ const MapView = forwardRef(({
         region={region}
         showsUserLocation
         showsMyLocationButton={false} // We will use our custom button
+        onRegionChangeComplete={setRegion}
         onPress={() => Keyboard.dismiss()}
       >
         {/* Campus markers (existing) */}
@@ -162,7 +163,7 @@ const MapView = forwardRef(({
         })}
 
         {/* Render point markers with custom circle + id text */}
-        {buildings
+        {region.longitudeDelta < 0.008 && buildings
           .filter((f) => f.geometry?.type === 'Point')
           .map((building) => {
             const coord = building.geometry.coordinates;

--- a/src/components/MapView.test.js
+++ b/src/components/MapView.test.js
@@ -311,6 +311,44 @@ describe('MapView', () => {
 
       expect(screen.getByTestId('map-view')).toBeTruthy();
     });
+
+    it('should hide building icons when user manually zooms out (longitudeDelta > 0.008)', () => {
+      render(
+        <MapView
+          center={mockCenter}
+          zoom={18} // gives longitudeDelta = 0.005 < 0.008
+          buildings={[mockPointBuilding]}
+        />
+      );
+
+      // MB should initially be shown
+      expect(screen.getByText('MB')).toBeTruthy();
+
+      // Zoom out manually to longitudeDelta = 0.01
+      const map = screen.getByTestId('react-native-map');
+      fireEvent(map, 'regionChangeComplete', {
+        latitude: mockCenter.latitude,
+        longitude: mockCenter.longitude,
+        latitudeDelta: 0.01,
+        longitudeDelta: 0.01,
+      });
+
+      // MB should be hidden
+      expect(screen.queryByText('MB')).toBeNull();
+    });
+
+    it('should start hidden if initial zoom is low (longitudeDelta > 0.008)', () => {
+      render(
+        <MapView
+          center={mockCenter}
+          zoom={15} // gives longitudeDelta = 0.02 > 0.008
+          buildings={[mockPointBuilding]}
+        />
+      );
+
+      // MB should be hidden initially
+      expect(screen.queryByText('MB')).toBeNull();
+    });
   });
 
   describe('Highlight Logic', () => {


### PR DESCRIPTION
This PR fixes issue #138 where building icons were cluttering the map when zoomed out. I updated the map to actively track its current zoom level, so now all building icons will automatically hide themselves once you zoom out past a certain point, keeping the map clean and readable. They reappear instantly when you zoom back in. I also added unit tests for this to make sure the logic stays intact.