### PR TITLE
Bug fix: Building info popup appears in directions search

### DIFF
--- a/src/screens/MapScreen.js
+++ b/src/screens/MapScreen.js
@@ -204,16 +204,12 @@ export default function MapScreen({ initialShowSearch = false }) {
     setOriginMode('manual');
     setOriginBuildingId(building.id);
     setOriginQuery(`${building.name} (${building.code})`);
-    setSelectedBuildingId(building.id);
-    setPopupVisible(true);
     Keyboard.dismiss();
   };
 
   const handleSelectDestinationFromSearch = (building) => {
     setDestinationBuildingId(building.id);
     setDestinationQuery(`${building.name} (${building.code})`);
-    setSelectedBuildingId(building.id);
-    setPopupVisible(true);
     Keyboard.dismiss();
   };
 


### PR DESCRIPTION
Fixes bug #183.

**Root cause:** 
In MapScreen.js, both handleSelectOriginFromSearch (line ~207) and handleSelectDestinationFromSearch (line ~215) were calling setSelectedBuildingId() and setPopupVisible(true), which caused the BuildingInfoPopup to slide up whenever a user selected a building from the search dropdown, even though it should only open when tapping a building directly on the map. 

**Fix Applied:**
Removed setSelectedBuildingId(building.id) and setPopupVisible(true) from both search selection handlers in MapScreen.js . The BuildingInfoPopup now only opens via handleBuildingPress (i.e., a direct map tap), which is the intended behavior. No other logic was changed — directions still work correctly when selecting buildings from the search fields.