### PR TITLE
Bug fix: Screen view dimensions for Android

### DIFF
--- a/src/screens/MapScreen.js
+++ b/src/screens/MapScreen.js
@@ -204,12 +204,16 @@ export default function MapScreen({ initialShowSearch = false }) {
     setOriginMode('manual');
     setOriginBuildingId(building.id);
     setOriginQuery(`${building.name} (${building.code})`);
+    setSelectedBuildingId(building.id);
+    setPopupVisible(true);
     Keyboard.dismiss();
   };
 
   const handleSelectDestinationFromSearch = (building) => {
     setDestinationBuildingId(building.id);
     setDestinationQuery(`${building.name} (${building.code})`);
+    setSelectedBuildingId(building.id);
+    setPopupVisible(true);
     Keyboard.dismiss();
   };
 


### PR DESCRIPTION
Fixes #104 

Summary: The initial bug reported was fixed with newer iterations of the app, but a problem remained with the black bar on top.
Cause: The StatusBar style was set to black, which covered the phone's own info bar.
Fix: Changed the styling of StatusBar to have a black background.