### PR TITLE
Bug fix (again): Building info popup appears in directions search

### DIFF
--- a/src/screens/MapScreen.js
+++ b/src/screens/MapScreen.js
@@ -204,16 +204,12 @@ export default function MapScreen({ initialShowSearch = false }) {
     setOriginMode('manual');
     setOriginBuildingId(building.id);
     setOriginQuery(`${building.name} (${building.code})`);
-    setSelectedBuildingId(building.id);
-    setPopupVisible(false);
     Keyboard.dismiss();
   };
 
   const handleSelectDestinationFromSearch = (building) => {
     setDestinationBuildingId(building.id);
     setDestinationQuery(`${building.name} (${building.code})`);
-    setSelectedBuildingId(building.id);
-    setPopupVisible(true);
     Keyboard.dismiss();
   };
 


### PR DESCRIPTION
Bug fixes #148.

Was originally fixed but then the lines were accidentally added again in a recent user-story PR which brought the bug back.